### PR TITLE
Custom Taxonomy not showing in Post Gutenberg editor

### DIFF
--- a/src/Raskoh/Taxonomy.php
+++ b/src/Raskoh/Taxonomy.php
@@ -130,6 +130,7 @@ class Taxonomy
             'show_admin_column' => $this->show_admin_column,
             'show_in_nav_menus' => $this->show_in_nav_menus,
             'show_tagcloud'     => $this->show_tagcloud,
+            'show_in_rest' => true,
         );
     }
 


### PR DESCRIPTION
Resolved issue: Enabled REST API support for custom post types and taxonomies by adding 'show_in_rest = true' to $args array. Please check. Thanks.